### PR TITLE
Fixed font settings being overriden globally.

### DIFF
--- a/docs/website/static/css/custom.css
+++ b/docs/website/static/css/custom.css
@@ -20,7 +20,7 @@
 }
 
 * {
-  font-family: Lato, "Helvetica Neue", Helvetica, Arial, sans-serif!important;
+  font-family: Lato, "Helvetica Neue", Helvetica, Arial, sans-serif;
 }
 
 .fixedHeaderContainer {


### PR DESCRIPTION
Among other things, this will make the `code` sections readable (i.e. have them use monospaced fonts).