### PR TITLE
Update documentation on testApp

### DIFF
--- a/docs/docs/testing.md
+++ b/docs/docs/testing.md
@@ -6,7 +6,7 @@ sidebar_label: Testing
 
 When working with ZeppelinOS, you can test your contracts as you usually do, or you can have ZeppelinOS automatically set up your entire application in your testing environment. This allows you to replicate the same set of contracts that manage your application for each test you run.
 
-The `zos` package provides a `TestApp()` function to retrieve your application structure from the `zos.json` file and deploy everything to the current test network. All contracts you have registered via `zos add`, plus all the contracts provided by the stdlib you have linked, will be available. The returned [`App`](https://github.com/zeppelinos/zos-lib/blob/master/src/app/App.js) object provides convenient methods for creating upgradeagble instances of your contracts, which you can use for testing.
+The `zos` package provides a `TestApp()` function to retrieve your application structure from the `zos.json` file and deploy everything to the current test network. All contracts you have registered via `zos add`, plus all the contracts provided by the stdlib you have linked, will be available. The returned [`App`](https://github.com/zeppelinos/zos-lib/blob/master/src/app/App.js) object provides convenient methods for creating upgradeable instances of your contracts, which you can use for testing.
 
 > **Important:** for `TestApp` to work correctly in your testing environment, you need to set the `NODE_ENV` environment variable to `test` when running your tests. For instance, if you are using truffle, run `NODE_ENV=test truffle test`.
 
@@ -33,10 +33,10 @@ To set up the full application in a test file, first import `TestApp` from `zos`
 import { TestApp } from 'zos';
 ```
 
-Then invoke it in the test suite setup, optionally including the path to your `zos.json` file, and a set of options to be used when deploying the contracts (such as `from`, `gas`, and `gasPrice`):
+Then invoke it in the test suite setup, optionally including a set of options to be used when deploying the contracts (such as `from`, `gas`, and `gasPrice`):
 ```js
 beforeEach(async function () {
-  this.app = await TestApp('zos.json', { from: owner })
+  this.app = await TestApp({ from: owner })
 });
 ```
 
@@ -61,7 +61,7 @@ const StandardToken = artifacts.require('StandardToken')
 contract('Sample', function ([_, owner]) {
 
   beforeEach(async function () {
-    this.app = await TestApp('zos.json', { from: owner })
+    this.app = await TestApp({ from: owner })
   });
 
   it('should create a proxy', async function () {


### PR DESCRIPTION
TestApp params usage was incorrect in the documentation (it was changed in 1.1 [here](https://github.com/zeppelinos/zos-cli/commit/3cceb10cc78f640f74e7fca0d902eb6cc963f93f#diff-6d9df1b2740c7ddfa2e5ee2593b02e41R3)). Documentation is now updated to reflect the changes from https://github.com/zeppelinos/zos-cli/pull/335.